### PR TITLE
Migrate all conf file to Jakarta EE 10 schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,6 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<org.imixs.workflow.version>6.0.3</org.imixs.workflow.version>
 		<microprofile.version>6.0</microprofile.version>
-		<microprofile-metrics.version>4.0</microprofile-metrics.version>	
 		<custom.webResources>src/main/webapp</custom.webResources>
 		<custom.unpackTypes>war</custom.unpackTypes>
 	</properties>
@@ -424,13 +423,6 @@
 			<groupId>jakarta.platform</groupId>
 			<artifactId>jakarta.jakartaee-api</artifactId>
 			<version>10.0.0</version>
-			<scope>provided</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>javax.faces</groupId>
-			<artifactId>jsf-api</artifactId>
-			<version>2.1</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<persistence version="1.0" xmlns="http://java.sun.com/xml/ns/persistence">
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd"
+             version="3.0">
 
 	<!--
 		Imixs JPA definition Make sure that the imixs-workflow-jee library

--- a/src/main/webapp/WEB-INF/beans.xml
+++ b/src/main/webapp/WEB-INF/beans.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
-       bean-discovery-mode="all" version="2.0">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
 </beans>

--- a/src/main/webapp/WEB-INF/faces-config.xml
+++ b/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,8 +1,8 @@
-<faces-config xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
-        http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_2.xsd"
-	version="2.2">
+<?xml version='1.0' encoding='UTF-8'?>
+<faces-config version="3.0"
+              xmlns="https://jakarta.ee/xml/ns/jakartaee"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_3_0.xsd">
 
 	<application>
 		<locale-config>

--- a/src/main/webapp/WEB-INF/glassfish-web.xml
+++ b/src/main/webapp/WEB-INF/glassfish-web.xml
@@ -4,29 +4,22 @@
 
 	<context-root>/</context-root>
 
-<!-- 
 	<security-role-mapping>
 		<role-name>org.imixs.ACCESSLEVEL.NOACCESS</role-name>
-		<group-name>IMIXS-WORKFLOW-Noaccess</group-name>
+		<group-name>org.imixs.ACCESSLEVEL.NOACCESS</group-name>
 	</security-role-mapping>
 	<security-role-mapping>
 		<role-name>org.imixs.ACCESSLEVEL.READERACCESS</role-name>
-		<group-name>IMIXS-WORKFLOW-Reader</group-name>
+		<group-name>org.imixs.ACCESSLEVEL.READERACCESS</group-name>
 	</security-role-mapping>
 	<security-role-mapping>
 		<role-name>org.imixs.ACCESSLEVEL.AUTHORACCESS</role-name>
-		<group-name>IMIXS-WORKFLOW-Author</group-name>
+		<group-name>org.imixs.ACCESSLEVEL.AUTHORACCESS</group-name>
 	</security-role-mapping>
 	<security-role-mapping>
 		<role-name>org.imixs.ACCESSLEVEL.EDITORACCESS</role-name>
-		<group-name>IMIXS-WORKFLOW-Editor</group-name>
+		<group-name>org.imixs.ACCESSLEVEL.EDITORACCESS</group-name>
 	</security-role-mapping>
-	<security-role-mapping>
-		<role-name>org.imixs.ACCESSLEVEL.MANAGERACCESS</role-name>
-		<group-name>IMIXS-WORKFLOW-Manager</group-name>
-		<principal-name>imixs-workflow-service</principal-name>
-	</security-role-mapping>
- -->
 
 	<security-role-mapping>
 		<role-name>org.imixs.ACCESSLEVEL.MANAGERACCESS</role-name>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns="http://java.sun.com/xml/ns/javaee"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-	version="3.0">
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+         version="6.0">
 	<display-name>Imixs Process Manager</display-name>
 	<welcome-file-list>
 		<welcome-file>pages/welcome.xhtml</welcome-file>
 	</welcome-file-list>
 	<context-param>
-		<param-name>javax.faces.PROJECT_STAGE</param-name>
+		<param-name>jakarta.faces.PROJECT_STAGE</param-name>
 		<param-value>Development</param-value>
 	</context-param>
 	


### PR DESCRIPTION
Remove javax dependency
Remove unused microprofile-metrics.version propertie

Restored security role mapping for Glassfish 7.0.x,  does not do group/role mapping by default if at least one mapping present